### PR TITLE
revert handling of the space in the env var

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,7 +52,7 @@ jobs:
           make test
 
       - name: Install Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v4
 
       - name: Pack Helm chart
         shell: bash

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"hash/fnv"
 	"sort"
-	"strings"
 	"time"
 
 	agentv1beta "github.com/lightrun-platform/lightrun-k8s-operator/api/v1beta"
@@ -230,7 +229,7 @@ func SetStatusCondition(conditions *[]metav1.Condition, newCondition metav1.Cond
 }
 
 func agentEnvVarArgument(mountPath string, agentCliFlags string) (string, error) {
-	agentArg := " -agentpath:" + mountPath + "/agent/lightrun_agent.so"
+	agentArg := "-agentpath:" + mountPath + "/agent/lightrun_agent.so"
 	if agentCliFlags != "" {
 		agentArg += "=" + agentCliFlags
 		if len(agentArg) > 1024 {
@@ -238,12 +237,6 @@ func agentEnvVarArgument(mountPath string, agentCliFlags string) (string, error)
 		}
 	}
 	return agentArg, nil
-}
-
-// Removes from env var value. Removes env var from the list if value is empty after the update
-func unpatchEnvVarValue(origValue string, removalValue string) string {
-	value := strings.ReplaceAll(origValue, removalValue, "")
-	return value
 }
 
 // Return index if the env var in the []corev1.EnvVar, otherwise -1

--- a/internal/controller/helpers_test.go
+++ b/internal/controller/helpers_test.go
@@ -53,58 +53,6 @@ func Test_findEnvVarIndex(t *testing.T) {
 	}
 }
 
-func Test_unpatchEnvVarValue(t *testing.T) {
-	type args struct {
-		origValue    string
-		removalValue string
-	}
-	tests := []struct {
-		name string
-		args args
-		want string
-	}{
-		{
-			name: "correctly removes the value from the env var",
-			args: args{
-				origValue:    "test",
-				removalValue: "test",
-			},
-			want: "",
-		},
-		{
-			name: "not found substring",
-			args: args{
-				origValue:    "test",
-				removalValue: "test1",
-			},
-			want: "test",
-		},
-		{
-			name: "with space",
-			args: args{
-				origValue:    "test this string",
-				removalValue: " this",
-			},
-			want: "test string",
-		},
-		{
-			name: "unpatch empty value",
-			args: args{
-				origValue:    "test this string",
-				removalValue: "",
-			},
-			want: "test this string",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := unpatchEnvVarValue(tt.args.origValue, tt.args.removalValue); got != tt.want {
-				t.Errorf("unpatchEnvVarValue() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func Test_agentEnvVarArgument(t *testing.T) {
 	type args struct {
 		mountPath     string
@@ -122,7 +70,7 @@ func Test_agentEnvVarArgument(t *testing.T) {
 				mountPath:     "test",
 				agentCliFlags: "test",
 			},
-			want:    " -agentpath:test/agent/lightrun_agent.so=test",
+			want:    "-agentpath:test/agent/lightrun_agent.so=test",
 			wantErr: false,
 		},
 		{
@@ -131,7 +79,7 @@ func Test_agentEnvVarArgument(t *testing.T) {
 				mountPath:     "test",
 				agentCliFlags: "",
 			},
-			want:    " -agentpath:test/agent/lightrun_agent.so",
+			want:    "-agentpath:test/agent/lightrun_agent.so",
 			wantErr: false,
 		},
 		{

--- a/internal/controller/lightrunjavaagent_controller.go
+++ b/internal/controller/lightrunjavaagent_controller.go
@@ -88,7 +88,7 @@ func (r *LightrunJavaAgentReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		}
 	}
 
-	if oldLrjaName, ok := originalDeployment.Annotations["lightrun.com/lightrunjavaagent"]; ok && oldLrjaName != lightrunJavaAgent.Name {
+	if oldLrjaName, ok := originalDeployment.Annotations[annotationAgentName]; ok && oldLrjaName != lightrunJavaAgent.Name {
 		log.Error(err, "Deployment already patched by LightrunJavaAgent", "Existing LightrunJavaAgent", oldLrjaName)
 		return r.errorStatus(ctx, lightrunJavaAgent, errors.New("deployment already patched"))
 	}
@@ -143,8 +143,8 @@ func (r *LightrunJavaAgentReconciler) Reconcile(ctx context.Context, req ctrl.Re
 				}
 
 			}
-			delete(originalDeployment.Annotations, "lightrun.com/patched-env-name")
-			delete(originalDeployment.Annotations, "lightrun.com/patched-env-value")
+			delete(originalDeployment.Annotations, annotationPatchedEnvName)
+			delete(originalDeployment.Annotations, annotationPatchedEnvValue)
 			err = r.Patch(ctx, originalDeployment, clientSidePatch)
 			if err != nil {
 				log.Error(err, "unable to unpatch "+lightrunJavaAgent.Spec.AgentEnvVarName)
@@ -276,8 +276,8 @@ func (r *LightrunJavaAgentReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			}
 		}
 	}
-	originalDeployment.Annotations["lightrun.com/patched-env-name"] = lightrunJavaAgent.Spec.AgentEnvVarName
-	originalDeployment.Annotations["lightrun.com/patched-env-value"] = agentArg
+	originalDeployment.Annotations[annotationPatchedEnvName] = lightrunJavaAgent.Spec.AgentEnvVarName
+	originalDeployment.Annotations[annotationPatchedEnvValue] = agentArg
 	err = r.Patch(ctx, originalDeployment, clientSidePatch)
 	if err != nil {
 		log.Error(err, "failed to patch "+lightrunJavaAgent.Spec.AgentEnvVarName)


### PR DESCRIPTION
due to the change in the string processing of ENV VAR (from 0.3.0) , on the existing installations (when there was no such variable before) operator is adding "new" string 2nd time, ignoring the previously added part.

This PR reverting this login