### PR TITLE
DEVOPS-2692-lightrun-k-8-s-operator-set-read-only-filesystem-for-init-container

### DIFF
--- a/internal/controller/patch_funcs.go
+++ b/internal/controller/patch_funcs.go
@@ -141,6 +141,7 @@ func (r *LightrunJavaAgentReconciler) addInitContainer(deploymentApplyConfig *ap
 					).
 					WithAllowPrivilegeEscalation(false).
 					WithRunAsNonRoot(true).
+					WithReadOnlyRootFilesystem(true).
 					WithSeccompProfile(
 						corev1ac.SeccompProfile().
 							WithType(corev1.SeccompProfileTypeRuntimeDefault),
@@ -316,6 +317,7 @@ func (r *LightrunJavaAgentReconciler) addInitContainerToStatefulSet(statefulSetA
 					).
 					WithAllowPrivilegeEscalation(false).
 					WithRunAsNonRoot(true).
+					WithReadOnlyRootFilesystem(true).
 					WithSeccompProfile(
 						corev1ac.SeccompProfile().
 							WithType(corev1.SeccompProfileTypeRuntimeDefault),


### PR DESCRIPTION
…t and stateful set configurations