### PR TITLE
DEVOPS-3434-fix-non-deterministic-configmap-hash-annotation-causing-unnecessary-pod-rollouts

### DIFF
--- a/internal/controller/patch_funcs.go
+++ b/internal/controller/patch_funcs.go
@@ -419,10 +419,14 @@ func (r *LightrunJavaAgentReconciler) patchStatefulSetAppContainers(lightrunJava
 
 // configMapDataHash calculates a hash of the ConfigMap data to detect changes
 func configMapDataHash(cmData map[string]string) uint64 {
-	// Combine all data values into a single string for hashing
+	keys := make([]string, 0, len(cmData))
+	for k := range cmData {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
 	var hashString string
-	for _, v := range cmData {
-		hashString += v
+	for _, k := range keys {
+		hashString += cmData[k]
 	}
 	return hash(hashString)
 }

--- a/internal/controller/patch_funcs_test.go
+++ b/internal/controller/patch_funcs_test.go
@@ -1,0 +1,84 @@
+package controller
+
+import (
+	"testing"
+)
+
+func Test_configMapDataHash(t *testing.T) {
+	tests := []struct {
+		name string
+		data map[string]string
+	}{
+		{
+			name: "empty map",
+			data: map[string]string{},
+		},
+		{
+			name: "single key",
+			data: map[string]string{
+				"config": "key1=value1\nkey2=value2\n",
+			},
+		},
+		{
+			name: "multiple keys",
+			data: map[string]string{
+				"config":   "max_log_size=100\nserver_url=https://app.lightrun.com\n",
+				"metadata": `{"tags":[{"name":"production"}],"agentName":"my-agent"}`,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			first := configMapDataHash(tt.data)
+			for i := 0; i < 100; i++ {
+				if got := configMapDataHash(tt.data); got != first {
+					t.Errorf("configMapDataHash() not deterministic: iteration %d got %v, want %v", i, got, first)
+				}
+			}
+		})
+	}
+}
+
+func Test_configMapDataHash_different_data(t *testing.T) {
+	a := map[string]string{
+		"config":   "key=value1\n",
+		"metadata": `{"agentName":"agent-a"}`,
+	}
+	b := map[string]string{
+		"config":   "key=value2\n",
+		"metadata": `{"agentName":"agent-a"}`,
+	}
+	c := map[string]string{
+		"config":   "key=value1\n",
+		"metadata": `{"agentName":"agent-b"}`,
+	}
+
+	hashA := configMapDataHash(a)
+	hashB := configMapDataHash(b)
+	hashC := configMapDataHash(c)
+
+	if hashA == hashB {
+		t.Errorf("expected different hashes for different config values, both got %v", hashA)
+	}
+	if hashA == hashC {
+		t.Errorf("expected different hashes for different metadata values, both got %v", hashA)
+	}
+}
+
+func Test_configMapDataHash_key_order_independent(t *testing.T) {
+	data1 := map[string]string{
+		"config":   "server=localhost\n",
+		"metadata": `{"agentName":"test"}`,
+	}
+	data2 := map[string]string{
+		"metadata": `{"agentName":"test"}`,
+		"config":   "server=localhost\n",
+	}
+
+	hash1 := configMapDataHash(data1)
+	hash2 := configMapDataHash(data2)
+
+	if hash1 != hash2 {
+		t.Errorf("hash should be independent of insertion order: got %v and %v", hash1, hash2)
+	}
+}


### PR DESCRIPTION
### Problem
  During releases (image tag updates), extra ReplicaSets are created beyond the expected 2 (old → new). This results in unnecessary intermediate rollout steps on every deployment.
### Root cause
  configMapDataHash() in patch_funcs.go iterates over a Go map without sorting keys. Go randomizes map iteration order, so the hash can differ between reconciliations even when ConfigMap data hasn't changed.
  
  During a release:
1. Image tag change triggers a reconcile
2. Operator patches the deployment with the new image + a hash value → creates a new ReplicaSet
3. The patch triggers another reconcile → hash may differ → another ReplicaSet
4. This repeats until two consecutive reconciles produce the same hash by chance
  With 2 keys in the map, each reconcile has ~50% probability of producing a different hash than the previous one.
### Fix
  Sort map keys before concatenating values for hashing, making the output deterministic.
### Impact
  Every release produces extra ReplicaSets and unnecessary intermediate rollouts, increasing deployment time and resource churn.