### PR TITLE
Devops 3479 changed k8s operator init java agent to multi arc

### DIFF
--- a/.github/workflows/init_container.yaml
+++ b/.github/workflows/init_container.yaml
@@ -25,7 +25,6 @@ on:
         type: boolean
 
 env:
-  IMAGE_NAME_PREFIX: lightruncom/k8s-operator-init-java-agent
   IMAGE_SUFFIX: ${{ inputs.is_internal == 'true' && '-internal' || '' }}
 
 jobs:
@@ -59,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and push ${{ matrix.base }}-${{ matrix.arch }}
     env:
-      IMAGE_REPO: ${{ env.IMAGE_NAME_PREFIX }}-${{ matrix.base }}-${{ matrix.arch }}${{ env.IMAGE_SUFFIX }}
+      IMAGE_REPO: lightruncom/k8s-operator-init-java-agent-${{ matrix.base }}-${{ matrix.arch }}${{ inputs.is_internal == 'true' && '-internal' || '' }}
       IMAGE_TAG: ${{ needs.resolve-image-tag.outputs.image_tag }}
     steps:
       - uses: actions/checkout@v4
@@ -109,7 +108,7 @@ jobs:
             archs: "amd64 arm64"
     name: Create multi-arch manifest for ${{ matrix.base }}
     env:
-      IMAGE_PREFIX: ${{ env.IMAGE_NAME_PREFIX }}-${{ matrix.base }}
+      IMAGE_PREFIX: lightruncom/k8s-operator-init-java-agent-${{ matrix.base }}
       IMAGE_TAG: ${{ needs.resolve-image-tag.outputs.image_tag }}
     steps:
       - name: Set up Docker Buildx

--- a/.github/workflows/init_container.yaml
+++ b/.github/workflows/init_container.yaml
@@ -18,48 +18,50 @@ on:
         description: "Internal release"
         required: false
         default: "true"
+      push_latest:
+        description: "Push latest on images"
+        required: false
+        default: true
+        type: boolean
+
+env:
+  IMAGE_NAME_PREFIX: lightruncom/k8s-operator-init-java-agent
+  IMAGE_SUFFIX: ${{ inputs.is_internal == 'true' && '-internal' || '' }}
 
 jobs:
-  set_image_tag_variable:
-    strategy:
-      matrix:
-        agents:
-          [
-            { name: "linux", file: "agent.zip", platform: "linux/amd64" },
-            {
-              name: "alpine",
-              file: "agent-alpine.zip",
-              platform: "linux/amd64",
-            },
-            {
-              name: "linux-arm64",
-              file: "agent-arm64.zip",
-              platform: "linux/arm64",
-            },
-            {
-              name: "alpine-arm64",
-              file: "agent-alpine-arm64.zip",
-              platform: "linux/arm64",
-            },
-          ]
+  resolve-image-tag:
     runs-on: ubuntu-latest
-    name: Build and push Docker image
+    outputs:
+      image_tag: ${{ steps.set_tag.outputs.image_tag }}
     steps:
-      - name: Set release tag
-        shell: bash
+      - name: Validate release tag and set image tag
+        id: set_tag
         run: |
-          # check that tag is matching regex x.y.x-release.<commit hash> or force flag is enabled
-          if [[ ! ${{ inputs.release_tag }} =~ ^[0-9]+\.[0-9]+\.[0-9]+-release\.[0-9a-f]+$ ]] ; then
-            echo "Tag ${{ inputs.release_tag }} is not matching regex x.y.x-release.<commithash>"
-            if [[ "${{ inputs.force }}" == "true" ]] ; then
-              echo "Force flag is enabled. Continue"
-            else
+          if [[ ! "${{ inputs.release_tag }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-release\.[0-9a-f]+$ ]] ; then
+            echo "Tag ${{ inputs.release_tag }} does not match x.y.z-release.<commithash>"
+            if [[ "${{ inputs.force }}" != "true" ]] ; then
               exit 1
             fi
+            echo "Force flag enabled. Continuing."
           fi
-          echo "TAG_NAME=$(echo ${{ inputs.release_tag }} | sed -E 's/^([0-9]*\.[0-9]*\.[0-9]*).*/\1/')-init.${{ inputs.init_image_tag }}"  >> "$GITHUB_OUTPUT"
-        id: set_tag
+          VERSION=$(echo "${{ inputs.release_tag }}" | sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+          echo "image_tag=${VERSION}-init.${{ inputs.init_image_tag }}" >> "$GITHUB_OUTPUT"
 
+  build:
+    needs: resolve-image-tag
+    strategy:
+      matrix:
+        include:
+          - { base: linux,  arch: amd64, file: agent.zip }
+          - { base: alpine, arch: amd64, file: agent-alpine.zip }
+          - { base: linux,  arch: arm64, file: agent-arm64.zip }
+          - { base: alpine, arch: arm64, file: agent-alpine-arm64.zip }
+    runs-on: ubuntu-latest
+    name: Build and push ${{ matrix.base }}-${{ matrix.arch }}
+    env:
+      IMAGE_REPO: ${{ env.IMAGE_NAME_PREFIX }}-${{ matrix.base }}-${{ matrix.arch }}${{ env.IMAGE_SUFFIX }}
+      IMAGE_TAG: ${{ needs.resolve-image-tag.outputs.image_tag }}
+    steps:
       - uses: actions/checkout@v4
 
       - name: Set up QEMU
@@ -68,7 +70,6 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
-        if: ${{ success() }}
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
@@ -81,78 +82,57 @@ jobs:
           aws-secret-access-key: ${{ secrets.RELEASE_ARTIFACTS_MANAGER_SECRET }}
           aws-region: us-east-1
 
-      - name: Set docker image tags
-        id: set_docker_tags
-        run: |
-          python3 -m pip install semver
-          existing_tags=()
-          
-          # Set repository suffix based on is_internal input
-          repo_suffix=""
-          if [[ "${{ inputs.is_internal }}" == "true" ]] ; then
-            repo_suffix="-internal"
-          fi
-          
-          
-          # Get Docker Hub JWT token
-          TOKEN=$(curl -s -H "Content-Type: application/json" \
-            -X POST -d '{"username": "${{ secrets.DOCKERHUB_USER }}", "password": "${{ secrets.DOCKERHUB_PASS }}"}' \
-            "https://hub.docker.com/v2/users/login/" | jq -r .token)
-          
-          if [[ -z "$TOKEN" ]] ; then
-            echo "Failed to get Docker Hub authentication token"
-            exit 1
-          fi
-          
-          # Define the base repository name
-          DOCKER_REPO="lightruncom/k8s-operator-init-java-agent-${{ matrix.agents.name }}${repo_suffix}"
-
-          # Check if repository exists
-          repo_check=$(curl -s -f -H "Authorization: Bearer ${TOKEN}" \
-            "https://hub.docker.com/v2/namespaces/lightruncom/repositories/k8s-operator-init-java-agent-${{ matrix.agents.name }}${repo_suffix}")
-          if [[ $? -ne 0 ]] ; then
-            echo "Error: Repository ${DOCKER_REPO} does not exist in Docker Hub. Please create it first."
-            exit 1
-          fi
-          
-          dockerhub_tags=$(curl -s -H "Authorization: Bearer ${TOKEN}" \
-            "https://hub.docker.com/v2/namespaces/lightruncom/repositories/k8s-operator-init-java-agent-${{ matrix.agents.name }}${repo_suffix}/tags?page_size=50" | jq -r ".results[].name")
-          if [[ $? -ne  0 ]] ; then
-            echo "Failed to fetch existing tags"
-            exit 1
-          fi
-          while IFS= read -r line; do
-            existing_tags+=("$line")
-          done < <(echo $dockerhub_tags)
-          for tag in $existing_tags
-          do
-            if [[ "$tag" == "latest" ]] ; then
-              continue
-            fi
-            echo "Comparing existing tag: $tag with new: ${{steps.set_tag.outputs.TAG_NAME}}"
-            if [[ $(pysemver compare $tag ${{steps.set_tag.outputs.TAG_NAME}}) -ge 0 ]] ; then
-              echo "Existing tag: $tag is greater or equal than new: ${{ inputs.release_tag }}. Skip adding latest tag"
-              echo "DOCKER_TAGS=${DOCKER_REPO}:${{steps.set_tag.outputs.TAG_NAME}}"  >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-          done
-          echo "Adding latest tag to ${{steps.set_tag.outputs.TAG_NAME}}"
-          echo "DOCKER_TAGS=${DOCKER_REPO}:${{steps.set_tag.outputs.TAG_NAME}},${DOCKER_REPO}:latest"  >> "$GITHUB_OUTPUT"
-
       - name: Download agent artifacts
         run: |
-          aws s3 cp s3://${{ secrets.RELEASE_ARTIFACTS_BUCKET }}/artifacts/${{ inputs.release_tag }}/${{ matrix.agents.file }} ./lightrun-init-agent/
+          aws s3 cp s3://${{ secrets.RELEASE_ARTIFACTS_BUCKET }}/artifacts/${{ inputs.release_tag }}/${{ matrix.file }} ./lightrun-init-agent/
 
-      - name: Build and push ${{ matrix.agents.name }} container
+      - name: Build and push image
         uses: docker/build-push-action@v4
         with:
           context: .
           file: ./lightrun-init-agent/Dockerfile
           push: true
-          platforms: ${{ matrix.agents.platform }}
-          tags: ${{steps.set_docker_tags.outputs.DOCKER_TAGS}}
+          platforms: linux/${{ matrix.arch }}
+          tags: ${{ env.IMAGE_REPO }}:${{ env.IMAGE_TAG }}${{ inputs.push_latest && format(',{0}:latest', env.IMAGE_REPO) || '' }}
           build-args: |
-            FILE=${{ matrix.agents.file }}
+            FILE=${{ matrix.file }}
+
+  create-manifests:
+    needs: [build, resolve-image-tag]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - base: linux
+            archs: "amd64 arm64"
+          - base: alpine
+            archs: "amd64 arm64"
+    name: Create multi-arch manifest for ${{ matrix.base }}
+    env:
+      IMAGE_PREFIX: ${{ env.IMAGE_NAME_PREFIX }}-${{ matrix.base }}
+      IMAGE_TAG: ${{ needs.resolve-image-tag.outputs.image_tag }}
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_PASS }}
+
+      - name: Create multi-arch manifest
+        run: |
+          BASE_REPO="${IMAGE_PREFIX}${IMAGE_SUFFIX}"
+          SOURCE_TAGS=""
+          for arch in ${{ matrix.archs }}; do
+            SOURCE_TAGS="${SOURCE_TAGS} ${IMAGE_PREFIX}-${arch}${IMAGE_SUFFIX}:${IMAGE_TAG}"
+          done
+          MANIFEST_TAGS=(--tag "${BASE_REPO}:${IMAGE_TAG}")
+          if [[ "${{ inputs.push_latest }}" == "true" ]]; then
+            MANIFEST_TAGS+=(--tag "${BASE_REPO}:latest")
+          fi
+          docker buildx imagetools create "${MANIFEST_TAGS[@]}" $SOURCE_TAGS
 
       - name: Slack Notification
         if: always()
@@ -160,6 +140,6 @@ jobs:
         env:
           SLACK_CHANNEL: devops-alerts
           SLACK_COLOR: ${{ job.status }}
-          SLACK_MESSAGE: "Tag ${{ inputs.release_tag }} ${{ inputs.is_internal == 'true' && '(Internal)' || '' }} | Platform ${{ matrix.agents.name }}"
+          SLACK_MESSAGE: "Image tag ${{ needs.resolve-image-tag.outputs.image_tag }} (release ${{ inputs.release_tag }}) ${{ inputs.is_internal == 'true' && '(Internal)' || '' }} | Base ${{ matrix.base }}"
           SLACK_TITLE: Init container ${{ inputs.is_internal == 'true' && '(Internal)' || '' }} build status - ${{ job.status }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/charts/lightrun-agents/README.md
+++ b/charts/lightrun-agents/README.md
@@ -46,24 +46,25 @@ The values.yaml file includes the following configurable parameters for each Jav
 
 Based on your workload's OS and architecture, you should select the appropriate DockerHub repository from the following options:
 
-- [linux amd64](https://hub.docker.com/repository/docker/lightruncom/k8s-operator-init-java-agent-linux/general)
-- [linux arm64](https://hub.docker.com/repository/docker/lightruncom/k8s-operator-init-java-agent-linux-arm64/general)
-- [alpine amd64](https://hub.docker.com/repository/docker/lightruncom/k8s-operator-init-java-agent-alpine/general)
-- [alpine arm64](https://hub.docker.com/repository/docker/lightruncom/k8s-operator-init-java-agent-alpine-arm64/general)
+- **Multi-arch clusters (recommended):** use the base repository (`linux` or `alpine`). Tags are version-only (for example `1.39.1-init.0` or `latest`); Kubernetes selects the correct architecture automatically.
+- **Single-arch clusters:** can use the architecture-specific repository (`linux-amd64`, `linux-arm64`, `alpine-amd64`, or `alpine-arm64`).
+
+Repositories:
+
+- Multi-arch: [linux](https://hub.docker.com/repository/docker/lightruncom/k8s-operator-init-java-agent-linux/general), [alpine](https://hub.docker.com/repository/docker/lightruncom/k8s-operator-init-java-agent-alpine/general)
+- linux: [amd64](https://hub.docker.com/repository/docker/lightruncom/k8s-operator-init-java-agent-linux-amd64/general), [arm64](https://hub.docker.com/repository/docker/lightruncom/k8s-operator-init-java-agent-linux-arm64/general)
+- alpine: [amd64](https://hub.docker.com/repository/docker/lightruncom/k8s-operator-init-java-agent-alpine-amd64/general), [arm64](https://hub.docker.com/repository/docker/lightruncom/k8s-operator-init-java-agent-alpine-arm64/general)
 
 After determining the appropriate image, you will need to choose a tag. The tag can either be "latest," which corresponds to the most up-to-date Lightrun version, or it can be a specific Lightrun version following the convention `<x.y.z>-init.<number>`. Typically, the `<number>` part is 0, but it is always good to verify on the DockerHub repository.
 
 For your convenience, here are some possible combinations of how the final image might look:
 
 ```text
-Linux amd64 with the latest version -> lightruncom/k8s-operator-init-java-agent-linux:latest
-Linux amd64 with a specific version -> lightruncom/k8s-operator-init-java-agent-linux:1.39.1-init.0
-Linux arm64 with the latest version -> lightruncom/k8s-operator-init-java-agent-linux-arm64:latest
-Linux arm64 with a specific version -> lightruncom/k8s-operator-init-java-agent-linux-arm64:1.39.1-init.0
-Alpine amd64 with the latest version -> lightruncom/k8s-operator-init-java-agent-alpine:latest
-Alpine amd64 with a specific version -> lightruncom/k8s-operator-init-java-agent-alpine:1.39.1-init.0
-Alpine arm64 with the latest version -> lightruncom/k8s-operator-init-java-agent-alpine-arm64:latest
-Alpine arm64 with a specific version -> lightruncom/k8s-operator-init-java-agent-alpine-arm64:1.39.1-init.0
+Linux (multi-arch), latest     -> lightruncom/k8s-operator-init-java-agent-linux:latest
+Linux (multi-arch), versioned  -> lightruncom/k8s-operator-init-java-agent-linux:1.39.1-init.0
+Linux arm64 only, versioned    -> lightruncom/k8s-operator-init-java-agent-linux-arm64:1.39.1-init.0
+Alpine (multi-arch), latest    -> lightruncom/k8s-operator-init-java-agent-alpine:latest
+Alpine arm64 only, versioned   -> lightruncom/k8s-operator-init-java-agent-alpine-arm64:1.39.1-init.0
 ```
 
 #### 2.2 Install the chart

--- a/docs/README.md
+++ b/docs/README.md
@@ -188,10 +188,8 @@ For simplicity, we maintain the same version for both the controller image and t
   - Alpine (x86_64, arm64)
 
   > **Available Init Containers:**
-  > - [Java agent for linux x86_64](https://hub.docker.com/r/lightruncom/k8s-operator-init-java-agent-linux/tags)
-  > - [Java agent for linux arm64](https://hub.docker.com/r/lightruncom/k8s-operator-init-java-agent-linux-arm64)
-  > - [Java agent for alpine x86_64](https://hub.docker.com/r/lightruncom/k8s-operator-init-java-agent-alpine/tags)
-  > - [Java agent for alpine arm64](https://hub.docker.com/r/lightruncom/k8s-operator-init-java-agent-alpine-arm64)
+  > - Multi-arch (recommended): [linux](https://hub.docker.com/r/lightruncom/k8s-operator-init-java-agent-linux/tags), [alpine](https://hub.docker.com/r/lightruncom/k8s-operator-init-java-agent-alpine/tags)
+  > - Single-arch: [linux-amd64](https://hub.docker.com/r/lightruncom/k8s-operator-init-java-agent-linux-amd64), [linux-arm64](https://hub.docker.com/r/lightruncom/k8s-operator-init-java-agent-linux-arm64), [alpine-amd64](https://hub.docker.com/r/lightruncom/k8s-operator-init-java-agent-alpine-amd64), [alpine-arm64](https://hub.docker.com/r/lightruncom/k8s-operator-init-java-agent-alpine-arm64)
 
 - **Kubernetes Resources:**
   - Deployment


### PR DESCRIPTION
**New repos**: Per-arch images
Before (4 repos):

```
lightruncom/k8s-operator-init-java-agent-linux:X.X.X-init.0 (amd64)
lightruncom/k8s-operator-init-java-agent-linux-arm64:X.X.X-init.0 
lightruncom/k8s-operator-init-java-agent-alpine:X.X.X-init.0 (amd64)
lightruncom/k8s-operator-init-java-agent-alpine-arm64:X.X.X-init.0 
```

After (6 repos)— 
```
per-arch:
lightruncom/k8s-operator-init-java-agent-linux-amd64:X.X.X-init.0
lightruncom/k8s-operator-init-java-agent-linux-arm64:X.X.X-init.0
lightruncom/k8s-operator-init-java-agent-alpine-amd64:X.X.X-init.0
lightruncom/k8s-operator-init-java-agent-alpine-arm64:X.X.X-init.0
multi-arch:
lightruncom/k8s-operator-init-java-agent-linux:X.X.X-init.0
lightruncom/k8s-operator-init-java-agent-alpine:X.X.X-init.0
```

still works for old users because if you used arm the image is still released to it, and if you use amd you will pull the multi arc, and it will fit your amd(new users can only use the 2 multi-arc repos)

**New input push_latest:** Explicit control over tagging latest on both per-arch and manifest images (default: true).
Removed automatic latest calculation — (repo check + tag listing (only 1 page) + python semver compare) — Redundant for the normal release path; manual runs can set push_latest: false when needed.
(default is true, so not breaking the promotion pipeline)

**Removed repo checks**: Anyone who can push to a branch can change the workflow in their branch to create  new repos in our org (only admins can do that);
