### PR TITLE
DEVOPS-2803-changed-default-useSecretsAsMountedFiles-to-true

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -157,6 +157,9 @@ jobs:
 
 
 
+          printf "\n\nDeployment spec after controller injection\n"
+          kubectl get deployment sample-deployment -o yaml
+
           printf "\n\nAgent log\n"
 
           log_file_name=/tmp/$(kubectl exec -t deploy/sample-deployment  - c app -- ls -t /tmp/ | grep lightrun_java_agent | head -n 1)

--- a/.github/workflows/tests_data/lightrunjavaagent.yaml
+++ b/.github/workflows/tests_data/lightrunjavaagent.yaml
@@ -10,7 +10,6 @@ spec:
   deploymentName: sample-deployment  
   secretName: lightrun-secrets 
   serverHostname: dogfood.internal.lightrun.com
-  useSecretsAsMountedFiles: false
   agentEnvVarName: JAVA_TOOL_OPTIONS
   agentConfig:
     max_log_cpu_cost: "2"

--- a/api/v1beta/lightrunjavaagent_types.go
+++ b/api/v1beta/lightrunjavaagent_types.go
@@ -95,7 +95,7 @@ type LightrunJavaAgentSpec struct {
 	AgentName string `json:"agentName,omitempty"`
 
 	// UseSecretsAsMountedFiles determines whether to use secret values as mounted files (true) or as environment variables (false)
-	// +kubebuilder:default=false
+	// +kubebuilder:default=true
 	UseSecretsAsMountedFiles bool `json:"useSecretsAsMountedFiles,omitempty"`
 }
 

--- a/charts/lightrun-agents/templates/java-agent-cr.yaml
+++ b/charts/lightrun-agents/templates/java-agent-cr.yaml
@@ -29,9 +29,7 @@ spec:
   secretName: {{ .name }}-secret
   {{- end }}
   serverHostname: {{ .serverHostname }}
-  {{- if .useSecretsAsMountedFiles }}
-  useSecretsAsMountedFiles: {{ .useSecretsAsMountedFiles | default false }}
-  {{- end }}
+  useSecretsAsMountedFiles: {{ .useSecretsAsMountedFiles | default true }}
   agentEnvVarName: {{ .agentEnvVarName | default "JAVA_TOOL_OPTIONS" }}
   {{- if .agentConfig }}
   agentConfig: {{ toYaml .agentConfig | nindent 4 }}

--- a/charts/lightrun-operator/crds/lightrunjavaagent_crd.yaml
+++ b/charts/lightrun-operator/crds/lightrunjavaagent_crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: lightrunjavaagents.agents.lightrun.com
 spec:
   group: agents.lightrun.com
@@ -124,7 +124,7 @@ spec:
                   Key and company id in the secret has to be taken from this server as well
                 type: string
               useSecretsAsMountedFiles:
-                default: false
+                default: true
                 description: UseSecretsAsMountedFiles determines whether to use secret
                   values as mounted files (true) or as environment variables (false)
                 type: boolean
@@ -152,16 +152,8 @@ spec:
             properties:
               conditions:
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -202,12 +194,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/charts/lightrun-operator/generated/rbac_manager_rules.yaml
+++ b/charts/lightrun-operator/generated/rbac_manager_rules.yaml
@@ -1,4 +1,24 @@
 - apiGroups:
+    - ""
+  resources:
+    - configmaps
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiGroups:
+    - ""
+  resources:
+    - secrets
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
     - agents.lightrun.com
   resources:
     - lightrunjavaagents
@@ -28,37 +48,9 @@
     - apps
   resources:
     - deployments
-  verbs:
-    - get
-    - list
-    - patch
-    - watch
-- apiGroups:
-    - apps
-  resources:
     - statefulsets
   verbs:
     - get
     - list
     - patch
-    - watch
-- apiGroups:
-    - ""
-  resources:
-    - configmaps
-  verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
-- apiGroups:
-    - ""
-  resources:
-    - secrets
-  verbs:
-    - get
-    - list
     - watch

--- a/config/crd/bases/agents.lightrun.com_lightrunjavaagents.yaml
+++ b/config/crd/bases/agents.lightrun.com_lightrunjavaagents.yaml
@@ -125,7 +125,7 @@ spec:
                   Key and company id in the secret has to be taken from this server as well
                 type: string
               useSecretsAsMountedFiles:
-                default: false
+                default: true
                 description: UseSecretsAsMountedFiles determines whether to use secret
                   values as mounted files (true) or as environment variables (false)
                 type: boolean
@@ -153,16 +153,8 @@ spec:
             properties:
               conditions:
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -203,12 +195,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -5,6 +5,26 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - agents.lightrun.com
   resources:
   - lightrunjavaagents
@@ -34,37 +54,9 @@ rules:
   - apps
   resources:
   - deployments
-  verbs:
-  - get
-  - list
-  - patch
-  - watch
-- apiGroups:
-  - apps
-  resources:
   - statefulsets
   verbs:
   - get
   - list
   - patch
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - list
   - watch

--- a/config/samples/operator.yaml
+++ b/config/samples/operator.yaml
@@ -14,7 +14,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: lightrunjavaagents.agents.lightrun.com
 spec:
   group: agents.lightrun.com
@@ -136,7 +136,7 @@ spec:
                   Key and company id in the secret has to be taken from this server as well
                 type: string
               useSecretsAsMountedFiles:
-                default: false
+                default: true
                 description: UseSecretsAsMountedFiles determines whether to use secret
                   values as mounted files (true) or as environment variables (false)
                 type: boolean
@@ -164,16 +164,8 @@ spec:
             properties:
               conditions:
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -214,12 +206,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -307,6 +294,26 @@ metadata:
   name: lightrun-k8s-operator-manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - agents.lightrun.com
   resources:
   - lightrunjavaagents
@@ -336,39 +343,11 @@ rules:
   - apps
   resources:
   - deployments
-  verbs:
-  - get
-  - list
-  - patch
-  - watch
-- apiGroups:
-  - apps
-  resources:
   - statefulsets
   verbs:
   - get
   - list
   - patch
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - list
   - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/examples/operator.yaml
+++ b/examples/operator.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: lightrunjavaagents.agents.lightrun.com
 spec:
   group: agents.lightrun.com
@@ -126,7 +126,7 @@ spec:
                   Key and company id in the secret has to be taken from this server as well
                 type: string
               useSecretsAsMountedFiles:
-                default: false
+                default: true
                 description: UseSecretsAsMountedFiles determines whether to use secret
                   values as mounted files (true) or as environment variables (false)
                 type: boolean
@@ -154,16 +154,8 @@ spec:
             properties:
               conditions:
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -204,12 +196,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -259,6 +246,26 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - agents.lightrun.com
     resources:
       - lightrunjavaagents
@@ -288,39 +295,11 @@ rules:
       - apps
     resources:
       - deployments
-    verbs:
-      - get
-      - list
-      - patch
-      - watch
-  - apiGroups:
-      - apps
-    resources:
       - statefulsets
     verbs:
       - get
       - list
       - patch
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - configmaps
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - secrets
-    verbs:
-      - get
-      - list
       - watch
 ---
 # Source: lightrun-k8s-operator/templates/metrics-reader-rbac.yaml

--- a/internal/controller/lightrunjavaagent_controller_test.go
+++ b/internal/controller/lightrunjavaagent_controller_test.go
@@ -1157,8 +1157,16 @@ var _ = Describe("LightrunJavaAgent controller", func() {
 				if err := k8sClient.Get(ctx, stsRequest, &patchedSts); err != nil {
 					return false
 				}
-				if len(patchedSts.Spec.Template.Spec.Volumes) == 2 {
-					return patchedSts.Spec.Template.Spec.Volumes[0].Name == initVolumeName
+				// 3 volumes: shared init volume, configmap volume, and secret volume (useSecretsAsMountedFiles defaults to true)
+				if len(patchedSts.Spec.Template.Spec.Volumes) == 3 {
+					hasInitVolume := patchedSts.Spec.Template.Spec.Volumes[0].Name == initVolumeName
+					hasSecretVolume := false
+					for _, v := range patchedSts.Spec.Template.Spec.Volumes {
+						if v.Name == "lightrun-secret" {
+							hasSecretVolume = true
+						}
+					}
+					return hasInitVolume && hasSecretVolume
 				}
 				return false
 			}, timeout, interval).Should(BeTrue())


### PR DESCRIPTION
Files under config/, examples/, and charts/lightrun-operator/crds/ are auto-generated by kubebuilder