### PR TITLE
DEVOPS-3506 [cascade] bump init-agent

### DIFF
--- a/lightrun-init-agent/Dockerfile
+++ b/lightrun-init-agent/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_image_tag=alpine-3.23.0-r4
+ARG base_image_tag=alpine-3.23.4-r0
 
 FROM lightruncom/prod-base:${base_image_tag}
 ARG FILE


### PR DESCRIPTION
## Cascade Run

| | |
|---|---|
| **Run ID** | 447266 |
| **Trigger** | manual |
| **Strategy** | patch |
| **Pipeline** | [link](https://dev.azure.com/athenat/Athena/_build/results?buildId=447266) |

### Related PRs

| Scope | Repo | PR |
|---|---|---|
| 0/devops | devops | #529 |
| 1/athena | athena | `cascade/447266/tier-1` |
| 1/devops | devops | `cascade/447266/tier-1` |
| 1/lightrun-k8s-operator | lightrun-k8s-operator | **this PR** |
| chart/lightrun-helm-chart | lightrun-helm-chart | `cascade/447266/chart` |

### Merge Order

This PR is in **scope 1**. Merge sequence: 0 → 1 → chart.
Wait for all earlier scope images to be published before merging.
