### PR TITLE
DEVOPS-3532 [cascade] bump lightrun-k8s-operator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-ARG golang_version=1.25.10
+ARG golang_version=1.25.11
 FROM golang:${golang_version} AS builder
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
## Cascade Run

| | |
|---|---|
| **Run ID** | 447963 |
| **Trigger** | manual |
| **Strategy** | patch |
| **Pipeline** | [link](https://dev.azure.com/athenat/Athena/_build/results?buildId=447963) |

### Upgrades

| Image | Dependency | Old | New |
|---|---|---|---|
| lightrun-k8s-operator | golang_version | 1.25.10 | 1.25.11 |

### Related PRs

| Scope | Repo | PR |
|---|---|---|
| 0/devops | devops | `cascade/447963/tier-0` |
| 0/lightrun-k8s-operator | lightrun-k8s-operator | **this PR** |
| 1/athena | athena | `cascade/447963/tier-1` |
| 1/devops | devops | `cascade/447963/tier-1` |
| 1/lightrun-k8s-operator | lightrun-k8s-operator | `cascade/447963/tier-1` |
| chart/lightrun-helm-chart | lightrun-helm-chart | `cascade/447963/chart` |

### Merge Order

This PR is in **scope 0**. Merge sequence: 0 → 1 → chart.
