### PR TITLE
DEVOPS-3547 [cascade] bump init-agent

### DIFF
--- a/lightrun-init-agent/Dockerfile
+++ b/lightrun-init-agent/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_image_tag=alpine-3.23.4-r2
+ARG base_image_tag=alpine-3.23.4-r4
 
 FROM lightruncom/prod-base:${base_image_tag}
 ARG FILE


### PR DESCRIPTION
## Cascade Run

| | |
|---|---|
| **Run ID** | 448060 |
| **Trigger** | manual |
| **Strategy** | patch |
| **Pipeline** | [link](https://dev.azure.com/athenat/Athena/_build/results?buildId=448060) |

### Related PRs

| Scope | Repo | PR |
|---|---|---|
| 0/devops | devops | [#539](https://github.com/lightrun-platform/devops/pull/539) |
| 1/athena | athena | _pending_ |
| 1/devops | devops | _pending_ |
| 1/lightrun-k8s-operator | lightrun-k8s-operator | **this PR** |
| chart/lightrun-helm-chart | lightrun-helm-chart | _pending_ |

### Merge Order

This PR is in **scope 1**. Merge sequence: 0 → 1 → chart.
Wait for all earlier scope images to be published before merging.
