### PR TITLE
DEVOPS-3597 [cascade] bump lightrun-k8s-operator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-ARG golang_version=1.25.11
+ARG golang_version=1.26.4
 FROM golang:${golang_version} AS builder
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
## Cascade Run

| | |
|---|---|
| **Run ID** | 451325 |
| **Trigger** | manual |
| **Strategy** | minor-patch |
| **Pipeline** | [link](https://dev.azure.com/athenat/Athena/_build/results?buildId=451325) |

### Upgrades

| Image | Dependency | Old | New |
|---|---|---|---|
| lightrun-k8s-operator | golang_version | 1.25.11 | 1.26.4 |

### Related PRs

| Scope | Repo | PR |
|---|---|---|
| 0/lightrun-k8s-operator | lightrun-k8s-operator | **this PR** |

### Merge Order

This PR is in **scope 0**. Merge sequence: 0 → 1 → chart.
