### PR TITLE
DEVOPS-3653 [cascade] bump lightrun-k8s-operator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-ARG golang_version=1.26.4
+ARG golang_version=1.26.5
 FROM golang:${golang_version} AS builder
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
## Cascade Run

| | |
|---|---|
| **Run ID** | 453741 |
| **Trigger** | manual |
| **Strategy** | minor-patch |
| **Pipeline** | [link](https://dev.azure.com/athenat/Athena/_build/results?buildId=453741) |

### Upgrades

| Image | Dependency | Old | New |
|---|---|---|---|
| lightrun-k8s-operator | golang_version | 1.26.4 | 1.26.5 |

### Related PRs

| Scope | Repo | PR |
|---|---|---|
| 0/devops | devops | _pending_ |
| 0/lightrun-k8s-operator | lightrun-k8s-operator | **this PR** |
| 1/athena | athena | _pending_ |
| 1/athena-qsr | athena-qsr | _pending_ |
| 1/devops | devops | _pending_ |
| 1/lightrun-k8s-operator | lightrun-k8s-operator | _pending_ |
| chart/lightrun-helm-chart | lightrun-helm-chart | _pending_ |
| chart/lightrun-helm-chart-qsr | lightrun-helm-chart-qsr | _pending_ |

### Merge Order

This PR is in **scope 0**. Merge sequence: 0 → 1 → chart.
