### PR TITLE
DEVOPS-3657 [cascade] bump init-agent

### DIFF
--- a/lightrun-init-agent/Dockerfile
+++ b/lightrun-init-agent/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_image_tag=alpine-3.24.1-r0
+ARG base_image_tag=alpine-3.24.1-r1
 
 FROM lightruncom/prod-base:${base_image_tag}
 ARG FILE


### PR DESCRIPTION
## Cascade Run

| | |
|---|---|
| **Run ID** | 453741 |
| **Trigger** | manual |
| **Strategy** | minor-patch |
| **Pipeline** | [link](https://dev.azure.com/athenat/Athena/_build/results?buildId=453741) |

### Related PRs

| Scope | Repo | PR |
|---|---|---|
| 0/devops | devops | [#557](https://github.com/lightrun-platform/devops/pull/557) |
| 0/lightrun-k8s-operator | lightrun-k8s-operator | [#87](https://github.com/lightrun-platform/lightrun-k8s-operator/pull/87) |
| 1/athena | athena | _pending_ |
| 1/athena-qsr | athena-qsr | _pending_ |
| 1/devops | devops | _pending_ |
| 1/lightrun-k8s-operator | lightrun-k8s-operator | **this PR** |
| chart/lightrun-helm-chart | lightrun-helm-chart | _pending_ |
| chart/lightrun-helm-chart-qsr | lightrun-helm-chart-qsr | _pending_ |

### Merge Order

This PR is in **scope 1**. Merge sequence: 0 → 1 → chart.
Wait for all earlier scope images to be published before merging.
